### PR TITLE
docs: update image path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<img src=".github/logo.png" width="394" align="center"></br>
+<img src="https://github.com/skibitsky/unity-now/raw/master/.github/logo.png" width="394" align="center"></br>
 <h1 align="center">Unity Now</h1>
 <p align="center">
 Deploy Unity WebGL builds on Zeit Now serverless platform with ease.


### PR DESCRIPTION
Use the absolute path, so the image can be displayed correctly on all branches e.g. upm. This will also fix the broken image link on the package's openupm page (after you merge changes to the upm branch, and wait around half-hour for the crawler to do the job). 

BTW, to sync upm branch automatically from your master branch please check out: https://medium.com/openupm/how-to-maintain-upm-package-part-1-7b4daf88d4c4